### PR TITLE
Refine visibility tracking logic

### DIFF
--- a/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityReducer.kt
+++ b/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityReducer.kt
@@ -15,17 +15,14 @@ internal fun MutableStateFlow<MainActivityState>.updateVisibleItems(
         val now = SystemClock.elapsedRealtime()
         state.copy(
             items = state.items.map { item ->
-                val start = visibleItems[item.id]?.value
-                val total = when {
-                    start != null ->
-                        item.previouslyAccumulatedVisibleTimeInMilliSeconds + (now - start)
-
-                    else -> item.previouslyAccumulatedVisibleTimeInMilliSeconds
-                }
-                item.copy(
-                    visibleTimeInMilliSeconds = total,
-                    formattedVisibleTimeInSeconds = total.toVisibleTime(),
-                )
+                visibleItems[item.id]?.let { start ->
+                    val total =
+                        item.previouslyAccumulatedVisibleTimeInMilliSeconds + (now - start.value)
+                    item.copy(
+                        visibleTimeInMilliSeconds = total,
+                        formattedVisibleTimeInSeconds = total.toVisibleTime(),
+                    )
+                } ?: item
             }
         )
     }
@@ -40,19 +37,15 @@ internal fun MutableStateFlow<MainActivityState>.updateNotVisibleItems(
         val timeSinceBecameVisible = now - elapsedRealTimeWhenBecameVisible.value
         state.copy(
             items = state.items.map { item ->
-                when (item.id) {
-                    itemId -> {
-                        val total =
-                            item.previouslyAccumulatedVisibleTimeInMilliSeconds + timeSinceBecameVisible
-                        item.copy(
-                            previouslyAccumulatedVisibleTimeInMilliSeconds = total,
-                            visibleTimeInMilliSeconds = total,
-                            formattedVisibleTimeInSeconds = total.toVisibleTime(),
-                        )
-                    }
-
-                    else -> item
-                }
+                if (item.id == itemId) {
+                    val total =
+                        item.previouslyAccumulatedVisibleTimeInMilliSeconds + timeSinceBecameVisible
+                    item.copy(
+                        previouslyAccumulatedVisibleTimeInMilliSeconds = total,
+                        visibleTimeInMilliSeconds = total,
+                        formattedVisibleTimeInSeconds = total.toVisibleTime(),
+                    )
+                } else item
             }
         )
     }

--- a/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-internal class MainActivityViewModel() : ViewModel() {
+internal class MainActivityViewModel : ViewModel() {
     private val _state = MutableStateFlow(initialState)
     internal val state = _state.asStateFlow()
 
@@ -29,9 +29,7 @@ internal class MainActivityViewModel() : ViewModel() {
         }
     }
 
-    internal val onAction: (MainActivityAction) -> Unit = { action -> processAction(action) }
-
-    private fun processAction(action: MainActivityAction) {
+    internal fun onAction(action: MainActivityAction) {
         when (action) {
             is BecameVisible -> visibleItems.asVisible(action.itemId)
             is BecameNotVisible -> visibleItems.asNotVisible(action.itemId)
@@ -39,16 +37,11 @@ internal class MainActivityViewModel() : ViewModel() {
     }
 
     private fun MutableMap<ItemId, ElapsedRealTimeWhenBecameVisible>.asVisible(itemId: ItemId) {
-        if (itemId !in this) {
-            this.put(
-                itemId,
-                ElapsedRealTimeWhenBecameVisible(SystemClock.elapsedRealtime()),
-            )
-        }
+        getOrPut(itemId) { ElapsedRealTimeWhenBecameVisible(SystemClock.elapsedRealtime()) }
     }
 
     private fun MutableMap<ItemId, ElapsedRealTimeWhenBecameVisible>.asNotVisible(itemId: ItemId) {
-        this.remove(itemId)?.let { start ->
+        remove(itemId)?.let { start ->
             _state.updateNotVisibleItems(elapsedRealTimeWhenBecameVisible = start, itemId = itemId)
         }
     }


### PR DESCRIPTION
## Summary
- handle actions with a straightforward function
- avoid copying unchanged items when updating visible/hidden times

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18eb9abc0832e84e7e5c0f0d67acc