### PR TITLE
Improve visibility tracking logic

### DIFF
--- a/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityReducer.kt
+++ b/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityReducer.kt
@@ -26,16 +26,15 @@ private fun MainActivityItemUi.updateItem(
     now: Long,
 ): MainActivityItemUi {
     val start = visibleItems[id]?.value
-    val total = when {
-        start != null ->
-            previouslyAccumulatedVisibleTimeInMilliSeconds + (now - start)
+    val total = start?.let {
+        val clampedDelta = (now - it).coerceAtLeast(0L)
+        previouslyAccumulatedVisibleTimeInMilliSeconds + clampedDelta
+    } ?: previouslyAccumulatedVisibleTimeInMilliSeconds
 
-        else -> previouslyAccumulatedVisibleTimeInMilliSeconds
-    }
-
-    return when (total) {
-        visibleTimeInMilliSeconds -> this
-        else -> copy(
+    return if (total == visibleTimeInMilliSeconds) {
+        this
+    } else {
+        copy(
             formattedVisibleTimeInSeconds = total.toVisibleTime(),
             visibleTimeInMilliSeconds = total,
         )

--- a/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityViewModel.kt
+++ b/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityViewModel.kt
@@ -42,18 +42,15 @@ internal class MainActivityViewModel(
     }
 
     private fun MutableMap<ItemId, ElapsedRealTimeWhenBecameVisible>.asVisible(itemId: ItemId) {
-        if (itemId !in this) {
-            this[itemId] = ElapsedRealTimeWhenBecameVisible(clock.now())
-        }
+        putIfAbsent(itemId, ElapsedRealTimeWhenBecameVisible(clock.now()))
     }
 
     private fun MutableMap<ItemId, ElapsedRealTimeWhenBecameVisible>.asNotVisible(itemId: ItemId) {
-        remove(itemId)?.let { start ->
-            _state.updateNotVisibleItem(
-                elapsedRealTimeWhenBecameVisible = start,
-                itemId = itemId,
-                now = clock.now()
-            )
-        }
+        val start = remove(itemId) ?: return
+        _state.updateNotVisibleItem(
+            elapsedRealTimeWhenBecameVisible = start,
+            itemId = itemId,
+            now = clock.now()
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Simplify visibility map handling in `MainActivityViewModel`
- Clamp negative deltas when calculating visible time

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching {languageVersion=17}...)*

------
https://chatgpt.com/codex/tasks/task_e_68c19f3fdd30832ea5eebfa2851aeb42