### PR TITLE
chore: bump kotlin to 2.2.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ composeBom = "2025.08.01"
 composeViewModel = "2.9.3"
 coroutinesTest = "1.10.2"
 junit4 = "4.13.2"
-kotlin = "2.2.10"
+kotlin = "2.2.20"
 material = "1.13.0"
 
 [libraries]


### PR DESCRIPTION
## Summary
- update Kotlin version to 2.2.20

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c19ee44384832ea5ee6cd93224b3f8