### PR TITLE
Ensure initial time formatting uses decimal precision

### DIFF
--- a/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityInitialState.kt
+++ b/app/src/main/kotlin/com/sotti/milliscope/data/MainActivityInitialState.kt
@@ -9,7 +9,7 @@ private val titleResId = R.string.app_name
 private val initialList =
     List(138) { index ->
         MainActivityItemUi(
-            formattedVisibleTimeInSeconds = "0",
+            formattedVisibleTimeInSeconds = "0.0",
             id = ItemId(index + 1),
             label = "Item ${index + 1}",
             visibleTimeInMilliSeconds = 0L,


### PR DESCRIPTION
## Summary
- Initialize items with `0.0` seconds to match runtime formatting

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a553d244832ead40327aff79dd9f