### PR TITLE
[codex] Update Android dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
-    alias(libs.plugins.kotlin.android)
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,5 +2,4 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    alias(libs.plugins.kotlin.android) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
-activityCompose = "1.11.0"
-agp = "8.13.0"
-composeBom = "2025.09.01"
-composeViewModel = "2.9.4"
+activityCompose = "1.13.0"
+agp = "9.1.0"
+composeBom = "2026.03.01"
+composeViewModel = "2.10.0"
 coroutines = "1.10.2"
 junit4 = "4.13.2"
-kotlin = "2.2.20"
+kotlin = "2.3.20"
 material = "1.13.0"
 
 [libraries]
@@ -20,5 +20,4 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## What changed
- bumped the Gradle wrapper from 9.0.0 to 9.4.1
- updated Android Gradle Plugin from 8.13.0 to 9.1.0
- updated Kotlin and the Compose compiler plugin from 2.2.20 to 2.3.20
- updated `activity-compose` from 1.11.0 to 1.13.0
- updated the Compose BOM from 2025.09.01 to 2026.03.01
- updated `lifecycle-viewmodel-compose` from 2.9.4 to 2.10.0
- removed the standalone `org.jetbrains.kotlin.android` plugin because AGP 9 now provides Kotlin support directly

## Why
This brings the project onto the latest stable Android build toolchain and direct UI/runtime dependencies while keeping the app building cleanly.

## Impact
- Gradle tasks now need to run on JDK 21 because of the AGP 9.1 upgrade.
- The app still compiles with Java 17 source/target compatibility.

## Validation
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :app:testDebugUnitTest :app:assembleDebug`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :app:lintDebug`
